### PR TITLE
Fix when image is Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 __pycache__/
+*Skyblog_Archive/

--- a/src/Scrapper.py
+++ b/src/Scrapper.py
@@ -24,7 +24,10 @@ def get_image (resultSet: ResultSet):
     if (image_container is None):
         return None
     image = image_container.find("img")
-    return image.get("src")
+    if (image is None):
+        return None
+    else:
+        return image.get("src")
 
 def get_texte (resultSet: ResultSet):
     # Get the content inside the div with the class text-container


### PR DESCRIPTION
An error is raised when video links from youtube are included in `img` tag.
Function return None in this case